### PR TITLE
Adding Altoros logo

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -47,7 +47,7 @@ landscape:
           - item:
             name: Altoros (member)
             homepage_url: 'https://www.altoros.com/'
-            logo: amazon-web-services.svg
+            logo: 'https://landscape.cncf.io/logos/altoros-member.svg'
             crunchbase: 'https://www.crunchbase.com/organization/altoros-systems'
           - item:
             name: Amazon Web Services (member)


### PR DESCRIPTION
Linking to the Altoros logo on the CNCF landscape site for the test entry for Altoros I added

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [ ] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [ ] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [ ] Have you picked the single best (existing) category for your project?
* [ ] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [ ] Have you included a URL for your SVG or added it to `hosted_logos` and referenced it there?
* [ ] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [ ] Does your project/product name match the text on the logo?
* [ ] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [ ] ~5 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
